### PR TITLE
fix: make uses-feature optional

### DIFF
--- a/fancycamera/src/main/AndroidManifest.xml
+++ b/fancycamera/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
     package="co.fitcom.fancycamera" >
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+	<uses-feature android:name="android.hardware.microphone" android:required="false" />
 </manifest>


### PR DESCRIPTION
This should be optional, to be able to target a maximum of devices. It's the responsability of the end-developer to narrow down and make it required if necessary. Maybe, those two lines should not be here at all, to avoid overriding issues.