### PR TITLE
feat: setCameraOrientation + expose hasFlash

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ compile 'co.fitcom:fancycamera:0.0.1'
 | getDuration()           |         | int     | Get the current recording video duration.             |
 | hasCamera()             |         | boolean | Checks if there are any camera available.             |
 | setCameraPosition()     |         | void    | Sets camera position front/back                       |
+| setCameraOrientation()  |         | void    | Used to force an orientation in the output file       |
 
 # TODO
 

--- a/fancycamera/build.gradle
+++ b/fancycamera/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.novoda.bintray-release'
 ext {
     PUBLISH_GROUP_ID = 'co.fitcom'
     PUBLISH_ARTIFACT_ID = 'fancycamera'
-    PUBLISH_VERSION = '0.6.8'
+    PUBLISH_VERSION = '0.7.0'
 }
 
 android {
@@ -43,7 +43,7 @@ publish {
     userOrg = 'triniwiz'
     groupId = 'co.fitcom'
     artifactId = 'fancycamera'
-    publishVersion = '0.6.8'
+    publishVersion = '0.7.0'
     desc = ''
     website = ''
 }

--- a/fancycamera/src/main/java/co/fitcom/fancycamera/Camera1.java
+++ b/fancycamera/src/main/java/co/fitcom/fancycamera/Camera1.java
@@ -42,6 +42,7 @@ public class Camera1 extends CameraBase {
     private Camera mCamera;
     private Context mContext;
     private FancyCamera.CameraPosition mPosition;
+    private FancyCamera.CameraOrientation mOrientation;
     private Handler backgroundHandler;
     private HandlerThread backgroundHandlerThread;
     private boolean isRecording;
@@ -487,6 +488,11 @@ public class Camera1 extends CameraBase {
         if (isStarted) {
             start();
         }
+    }
+    
+    @Override
+    void setCameraOrientation(FancyCamera.CameraOrientation orientation) {
+        mOrientation = orientation;
     }
 
 

--- a/fancycamera/src/main/java/co/fitcom/fancycamera/CameraBase.java
+++ b/fancycamera/src/main/java/co/fitcom/fancycamera/CameraBase.java
@@ -81,6 +81,7 @@ public abstract class CameraBase {
     abstract void release();
 
     abstract void setCameraPosition(FancyCamera.CameraPosition position);
+    abstract void setCameraOrientation(FancyCamera.CameraOrientation orientation);
 
     abstract void toggleFlash();
 

--- a/fancycamera/src/main/java/co/fitcom/fancycamera/FancyCamera.java
+++ b/fancycamera/src/main/java/co/fitcom/fancycamera/FancyCamera.java
@@ -30,6 +30,7 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
     private boolean mSaveToGallery = false;
     private boolean isStarted = false;
     private int mCameraPosition = 0;
+    private int mCameraOrientation = 0;
     private int mQuality = Quality.MAX_480P.getValue();
     private final Object mLock = new Object();
     private CameraEventListener listener;
@@ -88,7 +89,7 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
 
     private void init(Context context, @Nullable AttributeSet attrs) {
         if (Build.VERSION.SDK_INT >= 21) {
-            cameraBase = new Camera2(getContext(), this, CameraPosition.values()[getCameraPosition()]);
+            cameraBase = new Camera2(getContext(), this, CameraPosition.values()[getCameraPosition()], CameraOrientation.values()[getCameraOrientation()]);
         } else {
             cameraBase = new Camera1(getContext(), this, CameraPosition.values()[getCameraPosition()]);
         }
@@ -139,6 +140,8 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
                 setQuality(mQuality);
                 mCameraPosition = a.getInteger(R.styleable.FancyCamera_cameraPosition, 0);
                 setCameraPosition(mCameraPosition);
+                mCameraOrientation = a.getInteger(R.styleable.FancyCamera_cameraOrientation, 0);
+                setCameraOrientation(mCameraOrientation);
             } finally {
                 a.recycle();
             }
@@ -186,6 +189,10 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
         return mCameraPosition;
     }
 
+    public int getCameraOrientation() {
+        return mCameraOrientation;
+    }
+
     public int getDuration() {
         return cameraBase.getDuration();
     }
@@ -229,6 +236,14 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
 
     public void setCameraPosition(FancyCamera.CameraPosition position) {
         cameraBase.setCameraPosition(position);
+    }
+
+    public void setCameraOrientation(int orientation) {
+        cameraBase.setCameraOrientation(CameraOrientation.values()[orientation]);
+    }
+
+    public void setCameraOrientation(FancyCamera.CameraOrientation orientation) {
+        cameraBase.setCameraOrientation(orientation);
     }
 
     public void requestPermission() {
@@ -310,6 +325,23 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
         private int value;
 
         private Quality(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public enum CameraOrientation {
+        UNKNOWN(0),
+        PORTRAIT(1),
+        PORTRAIT_UPSIDE_DOWN(2),
+        LANDSCAPE_LEFT(3),
+        LANDSCAPE_RIGHT(4);
+        private int value;
+
+        CameraOrientation(int value) {
             this.value = value;
         }
 

--- a/fancycamera/src/main/java/co/fitcom/fancycamera/FancyCamera.java
+++ b/fancycamera/src/main/java/co/fitcom/fancycamera/FancyCamera.java
@@ -157,6 +157,10 @@ public class FancyCamera extends TextureView implements TextureView.SurfaceTextu
         return cameraBase.getFile();
     }
 
+    public boolean hasFlash() {
+        return cameraBase.hasFlash();
+    }
+
     public void toggleFlash() {
         cameraBase.toggleFlash();
     }

--- a/fancycamera/src/main/res/values/attrs.xml
+++ b/fancycamera/src/main/res/values/attrs.xml
@@ -16,5 +16,12 @@
             <enum name="back" value="0" />
             <enum name="front" value="1" />
         </attr>
+        <attr name="cameraOrientation" format="enum">
+            <enum name="unknown" value="0" />
+            <enum name="portrait" value="1" />
+            <enum name="portraitUpsideDown" value="2" />
+            <enum name="landscapeLeft" value="3" />
+            <enum name="landscapeRight" value="4" />
+        </attr>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Add the possibility to force an orientation in the output video file. Should be possible in case orientation is managed externaly, or orientation is known.

hasFlash() should also be exposed. I included it here, but there is some issues with the torch on Android, couldn't make it work yet with FancyCamera, need further investigations.