### PR TITLE
Rename attribute "position" to "cameraPosition" and fix the build err…

### DIFF
--- a/app/src/main/res/layout/activity_photo.xml
+++ b/app/src/main/res/layout/activity_photo.xml
@@ -11,7 +11,7 @@
         android:id="@+id/PhotoView"
         android:layout_width="match_parent"
         android:layout_height="174dp"
-        app:position="front" />
+        app:cameraPosition="front" />
 
 
     <Button

--- a/fancycamera/src/main/res/values/attrs.xml
+++ b/fancycamera/src/main/res/values/attrs.xml
@@ -12,7 +12,7 @@
             <enum name="lowest" value="5" />
             <enum name="qvga" value="6" />
         </attr>
-        <attr name="position" format="enum">
+        <attr name="cameraPosition" format="enum">
             <enum name="back" value="0" />
             <enum name="front" value="1" />
         </attr>


### PR DESCRIPTION
There is an open issue about build failure because of overlapping attribute name.

Rename the attribute "position" to "cameraPosition".